### PR TITLE
fix: navbar overlapping

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,7 +16,7 @@ const Header = () => {
 	return (
 		<nav
 			className={
-				"fixed top-0 left-0 h-[60px] w-full flex justify-center items-center mt-8"
+				"fixed top-0 left-0 h-[60px] w-full flex justify-center items-center mt-8 z-50"
 			}
 		>
 			<div


### PR DESCRIPTION
## Description
The navbar is now always on top of the contents.

## Images
### Previous
<img width="1192" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/abfbbfc5-7981-4e59-95eb-367b22b3f413">


### Current
<img width="1192" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/ab3ef3f5-ad18-46ad-9100-965366f9c571">
