### PR TITLE
feat: condense `Contact Me` section

### DIFF
--- a/src/features/contact_me/ContactMe.tsx
+++ b/src/features/contact_me/ContactMe.tsx
@@ -1,84 +1,66 @@
 import SVGIcon from "@/components/icons/SVGIcon";
 import SectionContainer from "@/components/sections/SectionContainer";
+import { Button } from "@/components/ui/button";
 import MessageMe from "@/features/contact_me/components/MessageMe";
+import { SOCIALS_LIST } from "@/features/contact_me/constants/SOCIALS_LIST";
+import { ISocial } from "@/features/contact_me/utils/types";
+import { cn } from "@/lib/utils";
+import { EnvelopeOpenIcon, Pencil1Icon } from "@radix-ui/react-icons";
+import Link from "next/link";
 import React from "react";
-import {
-	SimpleIcon,
-	siDevdotto,
-	siGithub,
-	siLinkedin,
-	siX,
-} from "simple-icons";
 
-interface ISocial {
-	name: string;
-	link: string;
-	icon: SimpleIcon;
-}
+const SocialButton = ({ social }: { social: ISocial }) => (
+	<Button variant={"secondary"} size={"icon"}>
+		<Link href={social.link} target={"_blank"} rel={"noopener noreferrer"}>
+			<SVGIcon icon={social.icon} className={"w-5 h-5"} />
+		</Link>
+	</Button>
+);
 
-const socials: Array<ISocial> = [
-	{
-		name: "LinkedIn",
-		link: "https://www.linkedin.com/in/akiomatic/",
-		icon: siLinkedin,
-	},
-	{ name: "GitHub", link: "https://github.com/akiomatic", icon: siGithub },
-	{ name: "X", link: "https://twitter.com/akiomatic", icon: siX },
-	{ name: "Dev.to", link: "https://dev.to/akiomatic", icon: siDevdotto },
-];
+const DirectInquiryButton = () => (
+	<Button variant={"secondary"} size={"icon"} className={"ml-2"}>
+		<a href={`mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}`}>
+			<EnvelopeOpenIcon className={"w-5 h-5"} />
+		</a>
+	</Button>
+);
 
 const ContactMe = () => {
 	return (
 		<SectionContainer
 			id={"contact-me"}
 			title={"Let's Connect!"}
-			className={"w-4/5 lg:w-1/2"}
+			className={cn("px-12", "w-screen lg:w-[1000px]", "text-base md:text-lg")}
 		>
-			{/*<div className={"flex flex-col justify-center items-center mt-12 bg-white backdrop-filter backdrop-blur-md w-3/4 lg:w-2/3 h-full rounded-full bg-opacity-20 border border-white border-opacity-20"}>*/}
-			<p className={"text-lg text-center px-12"}>
+			<p className={"text-center"}>
 				Thank you for exploring my portfolio. If I've caught your interest, feel
 				free to connect on social media! I'm open to new opportunities and
 				collaborations.
 			</p>
-			<div className={"flex pt-8 gap-x-8"}>
-				{socials.map((social) => {
-					return (
-						<a
-							key={social.name}
-							href={social.link}
-							target={"_blank"}
-							rel={"noopener noreferrer"}
-							className={
-								"flex items-center justify-center w-[30px] h-[30px] fill-[#E5ECF0]"
-							}
-						>
-							<SVGIcon icon={social.icon} />
-						</a>
-					);
-				})}
+			<div className={"flex py-8 gap-x-8"}>
+				{SOCIALS_LIST.map((social) => (
+					<SocialButton key={social.name} social={social} />
+				))}
 			</div>
-			<p className={"text-lg text-center mt-12"}>
-				To get in touch via email, contact me directly at:{" "}
-				<a href={`mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}`}>
-					<code className={"text-base px-2 py-0.5 border rounded-md"}>
-						{process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}
-					</code>
-				</a>
-				.
+			<p className={"flex justify-center items-center text-center"}>
+				For direct inquiries:
+				<DirectInquiryButton />
 			</p>
 			<MessageMe
-				className={"mb-8"}
-				buttonText={"Send me a message here 👋"}
 				title={"Contact Me"}
 				description={
 					"Thank you again for exploring my portfolio. If there's anything you'd like to discuss, share, or ask, feel free to message me there! I'm looking forward to connecting with you!"
 				}
 			>
-				<p className={"text-sm my-2"}>or</p>
+				<Button
+					variant={"outline"}
+					size={"default"}
+					className={cn("font-semibold mt-2", "md:text-base")}
+				>
+					Or send a direct message
+					<Pencil1Icon className={"w-5 h-5 ml-2"} />
+				</Button>
 			</MessageMe>
-			<p className={"text-lg text-center"}>
-				I'm looking forward to connecting with you!
-			</p>
 		</SectionContainer>
 	);
 };

--- a/src/features/contact_me/components/MessageMe.tsx
+++ b/src/features/contact_me/components/MessageMe.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -19,24 +18,15 @@ import {
 } from "@/components/ui/drawer";
 import MessageMeForm from "@/features/contact_me/components/MessageMeForm";
 import { Breakpoints, useMediaQuery } from "@/hooks/use-media-query";
-import { cn } from "@/lib/utils";
 import React, { useEffect, useState } from "react";
 
 interface IMessageMeProps {
 	children?: React.ReactNode;
-	className?: string;
-	buttonText: string;
 	title: string;
 	description: string;
 }
 
-const MessageMe = ({
-	children,
-	className,
-	buttonText,
-	title,
-	description,
-}: IMessageMeProps) => {
+const MessageMe = ({ children, title, description }: IMessageMeProps) => {
 	const [open, setOpen] = useState(false);
 	const [isJavaScriptEnabled, setIsJavaScriptEnabled] = useState(false);
 	const isDesktop = useMediaQuery(Breakpoints.md);
@@ -50,17 +40,8 @@ const MessageMe = ({
 	if (isDesktop) {
 		return (
 			<>
-				{children}
 				<Dialog open={open} onOpenChange={setOpen}>
-					<DialogTrigger asChild>
-						<Button
-							variant={"outline"}
-							size={"default"}
-							className={cn("text-base", className)}
-						>
-							{buttonText}
-						</Button>
-					</DialogTrigger>
+					<DialogTrigger asChild>{children}</DialogTrigger>
 					<DialogContent
 						className={
 							"max-w-[50%] flex flex-col justify-center items-center py-12"
@@ -86,17 +67,8 @@ const MessageMe = ({
 
 	return (
 		<>
-			{children}
 			<Drawer open={open} onOpenChange={setOpen}>
-				<DrawerTrigger asChild>
-					<Button
-						variant={"outline"}
-						size={"default"}
-						className={cn("text-base", className)}
-					>
-						{buttonText}
-					</Button>
-				</DrawerTrigger>
+				<DrawerTrigger asChild>{children}</DrawerTrigger>
 				<DrawerContent>
 					<DrawerHeader className="text-center pt-12">
 						<DrawerTitle className={"text-2xl"}>{title}</DrawerTitle>

--- a/src/features/contact_me/constants/SOCIALS_LIST.ts
+++ b/src/features/contact_me/constants/SOCIALS_LIST.ts
@@ -1,0 +1,13 @@
+import { ISocial } from "@/features/contact_me/utils/types";
+import { siDevdotto, siGithub, siLinkedin, siX } from "simple-icons";
+
+export const SOCIALS_LIST: Array<ISocial> = [
+	{
+		name: "LinkedIn",
+		link: "https://www.linkedin.com/in/akiomatic/",
+		icon: siLinkedin,
+	},
+	{ name: "GitHub", link: "https://github.com/akiomatic", icon: siGithub },
+	{ name: "X", link: "https://twitter.com/akiomatic", icon: siX },
+	{ name: "Dev.to", link: "https://dev.to/akiomatic", icon: siDevdotto },
+];

--- a/src/features/contact_me/utils/types.ts
+++ b/src/features/contact_me/utils/types.ts
@@ -1,0 +1,7 @@
+import { SimpleIcon } from "simple-icons";
+
+export interface ISocial {
+	name: string;
+	link: string;
+	icon: SimpleIcon;
+}


### PR DESCRIPTION
## Description
I've condensed the `Contact Me` section to improve readability because the old one was too tight and long.

## Changelog
- Created dedicated type and data files to manage socials
- Simplified the section to encourage sending messages to me
- Improved maintainability by modularizing components

## Images and videos
### Old
<img width="756" alt="Screenshot 2024-03-30 at 19 01 51" src="https://github.com/akiomatic/portfolio/assets/124953279/391956be-8b31-4384-8f02-3b65ccca1dfa">

### New design
<img width="983" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/b178a282-9567-4b0f-8a9d-0137d0a57d16">
