### PR TITLE
style: adjust width and padding for `About Me` section

### DIFF
--- a/src/features/about/About.tsx
+++ b/src/features/about/About.tsx
@@ -13,7 +13,7 @@ const About = () => {
 		>
 			<div
 				className={cn(
-					"flex justify-center items-center gap-14 mx-10",
+					"flex justify-center items-center gap-14 px-12",
 					"flex-col lg:flex-row",
 					"text-base md:text-lg",
 				)}

--- a/src/features/about/About.tsx
+++ b/src/features/about/About.tsx
@@ -9,7 +9,7 @@ const About = () => {
 		<SectionContainer
 			id={"about"}
 			title={"About Me"}
-			className={"w-screen xl:w-[1400px]"}
+			className={"w-screen max-w-[1400px]"}
 		>
 			<div
 				className={cn(

--- a/src/features/about/About.tsx
+++ b/src/features/about/About.tsx
@@ -9,7 +9,7 @@ const About = () => {
 		<SectionContainer
 			id={"about"}
 			title={"About Me"}
-			className={"w-screen max-w-[1400px]"}
+			className={"w-screen max-w-[1250px]"}
 		>
 			<div
 				className={cn(


### PR DESCRIPTION
## Description
I've modified the width and x-axis padding of `About Me` section to adjust the spacing between the content and the edge of the screen.

## Changelog
- Slightly increased the x-axis spacing
- Decreased the max-width from `1400px` to `1250px`

## Images
Before:
<img width="300" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/fcb061d8-6b32-44cb-97eb-cae2077dba8f">

After:
<img width="300" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/f9abe80d-9e05-4dfa-9693-9cc5190e0ec4">
