### PR TITLE
style: adjust `Navbar` items on light mode

### DIFF
--- a/src/features/navbar/Navbar.tsx
+++ b/src/features/navbar/Navbar.tsx
@@ -19,7 +19,7 @@ const Navbar = () => {
 	return (
 		<nav
 			className={
-				"fixed top-0 left-0 h-[60px] w-full flex justify-center items-center mt-8 z-50"
+				"fixed top-0 left-0 h-[55px] w-full flex justify-center items-center mt-8 z-50"
 			}
 		>
 			<NavbarContainer>

--- a/src/features/navbar/components/NavbarContainer.tsx
+++ b/src/features/navbar/components/NavbarContainer.tsx
@@ -35,7 +35,6 @@ const HomeLink = ({ children }: IHomeLinkProps) => {
 				"font-normal p-0",
 				"hover:bg-transparent",
 				"hidden sm:flex",
-				"text-sm sm:tex",
 			)}
 			asChild
 		>

--- a/src/features/navbar/components/NavbarContainer.tsx
+++ b/src/features/navbar/components/NavbarContainer.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
 
@@ -13,7 +14,6 @@ const NavbarContainer = ({ children }: INavbarContainerProps) => {
 				"w-full min-[380px]:w-11/12 lg:w-3/4 xl:w-2/3",
 				"px-5 md:px-6",
 				"justify-center sm:justify-between",
-				"text-sm sm:text-base",
 				"text-black dark:text-white",
 				" bg-white/40 dark:bg-gray-50/10 border-black/40 dark:border-gray-500/40",
 			)}
@@ -28,7 +28,20 @@ interface IHomeLinkProps {
 }
 
 const HomeLink = ({ children }: IHomeLinkProps) => {
-	return <div className={"hidden sm:flex"}>{children}</div>;
+	return (
+		<Button
+			variant={"ghost"}
+			className={cn(
+				"font-normal p-0",
+				"hover:bg-transparent",
+				"hidden sm:flex",
+				"text-sm sm:tex",
+			)}
+			asChild
+		>
+			{children}
+		</Button>
+	);
 };
 
 NavbarContainer.HomeLink = HomeLink;

--- a/src/features/navbar/components/NavbarItems.tsx
+++ b/src/features/navbar/components/NavbarItems.tsx
@@ -26,8 +26,8 @@ const NavbarItem = ({ section }: INavbarItemProps) => {
 			className={cn(
 				"h-full py-1 rounded-full transition-all font-normal",
 				"hover:bg-gray-500/20 sm:hover:bg-gray-500/30 dark:hover:bg-white/20 dark:sm:hover:bg-white/30",
-				"sm:bg-gray-500/20 dark:sm:bg-white/20",
-				"text-sm sm:text-base",
+				"bg-transparent sm:bg-gray-500/20 dark:sm:bg-white/20",
+				"shadow-none sm:shadow",
 				"text-black dark:text-white",
 				"px-4",
 			)}

--- a/src/features/navbar/components/NavbarItems.tsx
+++ b/src/features/navbar/components/NavbarItems.tsx
@@ -24,8 +24,8 @@ const NavbarItem = ({ section }: INavbarItemProps) => {
 		<div
 			className={cn(
 				"h-full py-1 rounded-full transition-all",
-				"hover:bg-white hover:bg-opacity-20 sm:hover:bg-opacity-30",
-				"sm:bg-white sm:bg-opacity-20",
+				"hover:bg-gray-500/20 sm:hover:bg-gray-500/30 dark:hover:bg-white/20 dark:sm:hover:bg-white/30",
+				"sm:bg-gray-500/20 dark:sm:bg-white/20",
 				"px-4",
 			)}
 		>

--- a/src/features/navbar/components/NavbarItems.tsx
+++ b/src/features/navbar/components/NavbarItems.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { ISection } from "@/features/navbar/Navbar";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
@@ -21,13 +22,16 @@ interface INavbarItemProps {
 
 const NavbarItem = ({ section }: INavbarItemProps) => {
 	return (
-		<div
+		<Button
 			className={cn(
-				"h-full py-1 rounded-full transition-all",
+				"h-full py-1 rounded-full transition-all font-normal",
 				"hover:bg-gray-500/20 sm:hover:bg-gray-500/30 dark:hover:bg-white/20 dark:sm:hover:bg-white/30",
 				"sm:bg-gray-500/20 dark:sm:bg-white/20",
+				"text-sm sm:text-base",
+				"text-black dark:text-white",
 				"px-4",
 			)}
+			asChild
 		>
 			<Link href={`#${section.targetId}`}>
 				<>
@@ -35,7 +39,7 @@ const NavbarItem = ({ section }: INavbarItemProps) => {
 					<p className={"hidden sm:block"}>{section.name}</p>
 				</>
 			</Link>
-		</div>
+		</Button>
 	);
 };
 

--- a/src/features/navbar/components/ThemeToggle.tsx
+++ b/src/features/navbar/components/ThemeToggle.tsx
@@ -21,8 +21,8 @@ export const ThemeToggle = () => {
 					size={"icon"}
 					className={cn(
 						"size-[30px] transition-all ring-transparent focus-visible:ring-transparent",
-						"hover:bg-white hover:bg-opacity-20 sm:hover:bg-opacity-30",
-						"bg-transparent sm:bg-white sm:bg-opacity-20",
+						"hover:bg-gray-500/20 sm:hover:bg-gray-500/30 dark:hover:bg-white/20 dark:sm:hover:bg-white/30",
+						"sm:bg-gray-500/20 dark:sm:bg-white/20",
 					)}
 				>
 					<SunIcon className="size-[15px] text-black rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/src/features/navbar/components/ThemeToggle.tsx
+++ b/src/features/navbar/components/ThemeToggle.tsx
@@ -22,7 +22,8 @@ export const ThemeToggle = () => {
 					className={cn(
 						"size-[30px] transition-all ring-transparent focus-visible:ring-transparent",
 						"hover:bg-gray-500/20 sm:hover:bg-gray-500/30 dark:hover:bg-white/20 dark:sm:hover:bg-white/30",
-						"sm:bg-gray-500/20 dark:sm:bg-white/20",
+						"shadow-none sm:shadow",
+						"bg-transparent sm:bg-gray-500/20 dark:sm:bg-white/20",
 					)}
 				>
 					<SunIcon className="size-[15px] text-black rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
## Description
I've adjusted the font size, default background/text colors, background colors on hovering, and shadow, especially for light mode.

## Changelog
- Now use the `button` component from `shadcn/ui`
- Adjusted the default background/text colors, background colors on hovering, and shadow
- Changed the default font size to 14px (`sm`)
- Made `Navbar` shorter to 55px, previously 60px

## Images
### Old
<img width="1277" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/996358f0-c9d1-4b4a-b06f-09e0335a4d1b">

### New
<img width="1276" alt="image" src="https://github.com/akiomatic/portfolio/assets/124953279/26015e8a-af8a-4075-83ff-5d2201c487c4">

## Video
https://github.com/akiomatic/portfolio/assets/124953279/b58c1ac2-5257-469d-bd9b-cc80e74763c7

